### PR TITLE
Fix bug where wrong NFT shows when visiting URL

### DIFF
--- a/web-previewer/src/components/useRouteParameterSync.js
+++ b/web-previewer/src/components/useRouteParameterSync.js
@@ -8,6 +8,7 @@ export default function useRouteParameterSync(previewState) {
   onMounted(() => {
     if (route.query.developerId) {
       previewState.developer.value = route.query.developerId;
+      previewState.updateTraits();
     }
   });
 


### PR DESCRIPTION
Issue: When visiting a URL with `?developerId` the traits were always the same (Developer 1's traits).

This fix reloads the Traits when visiting the URL.

Fixes #52 