### PR TITLE
Add README Badges for Solidity Tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Solidity contract tests
 on:
   push:
     paths-ignore:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Derivatives Project
 
+![Solidity contract tests](https://github.com/Developer-DAO/pixel-avatars/actions/workflows/continuous-integration.yaml/badge.svg)
+
 ## Project
 The Derivatives project, originally known as the pixel-avatars project is created initially to allow the minting of a derived Pixel Avatar ERC721 NFT token generated based on the traits of the original DeveloperDAO genesis NFTs; similar to how Loot has its own derivatives projects.
 

--- a/contract/README.md
+++ b/contract/README.md
@@ -2,6 +2,8 @@
 
 This is the smart contract for the Developer DAO pixel avatar NFT.
 
+![Solidity contract tests](https://github.com/Developer-DAO/pixel-avatars/actions/workflows/continuous-integration.yaml/badge.svg)
+
 ## Installation
 
 ### Install dependencies


### PR DESCRIPTION
Show status of Solidity tests as a badge in the root README and the `contracts` README.