### PR TITLE
Fix public key for each environment

### DIFF
--- a/web-server/cli/generate-action-secret.js
+++ b/web-server/cli/generate-action-secret.js
@@ -1,19 +1,30 @@
 const { generateKeypair } = require('../src/utils')
 const sodium = require('tweetsodium')
 
+const environments = {
+    Staging: {
+        name: 'Staging',
+        publicKeyId: '568250167242549743',
+        publicKey: 'YpCq4GbO4oWsRvJ4br0rhaGCLrvv/SrNtTBt2QWPTX4=',
+    },
+    Production: {
+        name: 'Production',
+        publicKeyId: '568250167242549743',
+        publicKey: 'bxKnGP3uYODWJXcLxeguz1TZ1wq3q+N3raTM+jCnB2I=',
+    },
+}
+
 const config = {
     repo: 'Developer-DAO/pixel-avatars',
-    environmentName: process.argv[2] ?? 'Production',
-    publicKeyId: '568250167242549743',
-    publicKey: 'FUbH7LzIYoY9JTygD0YkyLkkrQULdMnFssoCo/YRgWc=',
     secretName: 'SERVER_PRIVATE_KEY',
+    environment: environments[process.argv[2] ?? 'Production']
 }
 
 const keypair = generateKeypair()
 
 // Convert the message and key to Uint8Array's (Buffer implements that interface)
 const messageBytes = Buffer.from(keypair.privateKey)
-const keyBytes = Buffer.from(config.publicKey, 'base64')
+const keyBytes = Buffer.from(config.environment.publicKey, 'base64')
 
 // Encrypt using LibSodium.
 const encryptedBytes = sodium.seal(messageBytes, keyBytes)
@@ -23,7 +34,7 @@ const encrypted = Buffer.from(encryptedBytes).toString('base64')
 
 console.log(`To update GitHub Action Secret please run following command: \n`)
 console.log(
-    `hub api -XPUT /repos/${config.repo}/environments/${config.environmentName}/secrets/${config.secretName} -f key_id="${config.publicKeyId}" -f encrypted_value="${encrypted}"\n`
+    `hub api -XPUT /repos/${config.repo}/environments/${config.environment.name}/secrets/${config.secretName} -f key_id="${config.environment.publicKeyId}" -f encrypted_value="${encrypted}"\n`
 )
 console.log(`(requires http://hub.github.com installed)\n`)
 console.log(`Please set contract SERVER_ADDRESS=${keypair.address}`)

--- a/web-server/cli/generate-action-secret.js
+++ b/web-server/cli/generate-action-secret.js
@@ -17,7 +17,7 @@ const environments = {
 const config = {
     repo: 'Developer-DAO/pixel-avatars',
     secretName: 'SERVER_PRIVATE_KEY',
-    environment: environments[process.argv[2] ?? 'Production']
+    environment: environments[process.argv[2] ?? 'Production'],
 }
 
 const keypair = generateKeypair()


### PR DESCRIPTION
So while doing the end-to-end test I discovered that SERVER_PRIVATE_KEY didn't get written properly to the environment-secrets. While it would read "Updated just now" it would read out as being empty when the action runs. 

Turns out that GH has separate key-pairs for each environment / "general action secrets" even though they all share the same "Key Id". I fixes this by hardcoding each of the key-pairs into the generate command. 

Oh boi did that take me a while to figure out 😂...