### PR TITLE
Feat/erc2981 royalties

### DIFF
--- a/contract/contracts/@eip2981/ERC2981Base.sol
+++ b/contract/contracts/@eip2981/ERC2981Base.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GNU General Public License v3.0
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import "./IERC2981Royalties.sol";
+
+/// @dev This is a contract used to add ERC2981 support to ERC721 and 1155
+abstract contract ERC2981Base is ERC165, IERC2981Royalties {
+    struct RoyaltyInfo {
+        address recipient;
+        uint24 amount;
+    }
+
+    /// @inheritdoc	ERC165
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IERC2981Royalties).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contract/contracts/@eip2981/ERC2981ContractWideRoyalties.sol
+++ b/contract/contracts/@eip2981/ERC2981ContractWideRoyalties.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GNU General Public License v3.0
+pragma solidity ^0.8.10;
+
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import "./ERC2981Base.sol";
+
+/// @dev This is a contract used to add ERC2981 support to ERC721 and 1155
+/// @dev This implementation has the same royalties for each and every tokens
+abstract contract ERC2981ContractWideRoyalties is ERC2981Base {
+    RoyaltyInfo private _royalties;
+
+    /// @dev Sets token royalties
+    /// @param recipient recipient of the royalties
+    /// @param value percentage (using 2 decimals - 10000 = 100, 0 = 0)
+    function _setRoyalties(address recipient, uint256 value) internal {
+        require(value <= 10000, "ERC2981Royalties: Too high");
+        _royalties = RoyaltyInfo(recipient, uint24(value));
+    }
+
+    /// @inheritdoc	IERC2981Royalties
+    function royaltyInfo(uint256, uint256 value)
+        external
+        view
+        override
+        returns (address receiver, uint256 royaltyAmount)
+    {
+        RoyaltyInfo memory royalties = _royalties;
+        receiver = royalties.recipient;
+        royaltyAmount = (value * royalties.amount) / 10000;
+    }
+}

--- a/contract/contracts/@eip2981/IERC2981Royalties.sol
+++ b/contract/contracts/@eip2981/IERC2981Royalties.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GNU General Public License v3.0
+pragma solidity ^0.8.10;
+
+/// @title IERC2981Royalties
+/// @dev Interface for the ERC2981 - Token Royalty standard
+interface IERC2981Royalties {
+    /// @notice Called with the sale price to determine how much royalty
+    //          is owed and to whom.
+    /// @param _tokenId - the NFT asset queried for royalty information
+    /// @param _value - the sale price of the NFT asset specified by _tokenId
+    /// @return _receiver - address of who should be sent the royalty payment
+    /// @return _royaltyAmount - the royalty payment amount for value sale price
+    function royaltyInfo(uint256 _tokenId, uint256 _value)
+        external
+        view
+        returns (address _receiver, uint256 _royaltyAmount);
+}

--- a/contract/contracts/PixelAvatars.sol
+++ b/contract/contracts/PixelAvatars.sol
@@ -5,13 +5,15 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
+import "./@eip2981/ERC2981ContractWideRoyalties.sol";
 
 /// @author Developer DAO
 /// @title The Pixel Avatar smart contract that is compliant to ERC721 standard and is upgradeable
 contract PixelAvatars is
     ERC721EnumerableUpgradeable,
     ReentrancyGuardUpgradeable,
-    OwnableUpgradeable
+    OwnableUpgradeable,
+    ERC2981ContractWideRoyalties
 {
     string public baseURI;
     uint256 public mintPrice;
@@ -29,6 +31,8 @@ contract PixelAvatars is
         __ERC721_init("Pixel Avatars", "PXLDEV");
         __Ownable_init();
 
+        setRoyalties(10000); // On initialize set 10% royalty fee
+
         baseURI = "ipfs://QmZdT5R5XGQVwGnnpiS6dGjUHZh6z8JjpuHhsqcLMMeWiC/";
         mintPrice = 12 ether;
 
@@ -37,8 +41,11 @@ contract PixelAvatars is
         // mintPrice = 0.01 ether;
     }
 
-    function _baseURI() internal view virtual override returns (string memory) {
-        return baseURI;
+    /**
+     * @param amount The amount of royalties to be set.
+     */
+    function setRoyalties(uint256 amount) external onlyOwner {
+        _setRoyalties(msg.sender, amount);
     }
 
     function setBaseURI(string memory _newBaseURI) external onlyOwner {
@@ -102,5 +109,9 @@ contract PixelAvatars is
 
     function withdraw() external onlyOwner {
         payable(msg.sender).transfer(address(this).balance);
+    }
+
+    function _baseURI() internal view virtual override returns (string memory) {
+        return baseURI;
     }
 }


### PR DESCRIPTION
# Overview

This PR is specifically for adding support to royalties via EIP-2981 standard. This is specific to OpenSea royalties implementation.

Here are the references I've used to learn its implementation from the past few months:
- GitHub Repository: [EIP2981-implementation](https://github.com/dievardump/EIP2981-implementation)
- Forum Post form OpenZeppelin: ["Has anyone implemented EIP 2981"](https://forum.openzeppelin.com/t/has-anyone-implemented-eip-2981/14547/11)
- A Gemini Article: ["Exploring the NFT Royalty Standard (EIP-2981)"](https://www.gemini.com/blog/exploring-the-nft-royalty-standard-eip-2981)
- Official Document from Ethereum: ["EIP-2981: NFT Royalty Standard "](https://eips.ethereum.org/EIPS/eip-2981)
- Medium Post: ["EIP-2981 — Simple and effective royalty standard for all"](https://medium.com/knownorigin/eip-2981-simple-and-effective-royalty-standards-for-all-dbd0b761a0f0)
- And finally... a useful YouTube video tutorial: ["Custom ERC721 With Secondary Royalties (OpenSea, Rarible, Mintable) - From Scratch with Truffle"](https://www.youtube.com/watch?v=LHZC9wX3r0I)

I hope these resources helps out for anyone interested to learn more about the secondary market shares preparation/implementation on a smart contract.